### PR TITLE
Stop using shared private secret scanning action

### DIFF
--- a/.github/workflows/secret_scanning.yml
+++ b/.github/workflows/secret_scanning.yml
@@ -6,5 +6,24 @@ on:
   pull_request:
 
 jobs:
-  secret_scanning:
-    uses: xelixdev/.github/.github/workflows/secret_scanning.yml@main
+  check_commits:
+    runs-on: ubuntu-latest
+    steps:
+    - name: Set depth and branch variables
+      run: |
+        if [ "${{ github.event_name }}" == "push" ]; then
+          echo "depth=$(($(jq length <<< '${{ toJson(github.event.commits) }}') + 2))" >> $GITHUB_ENV
+          echo "branch=${{ github.ref_name }}" >> $GITHUB_ENV
+        fi
+        if [ "${{ github.event_name }}" == "pull_request" ]; then
+          echo "depth=$((${{ github.event.pull_request.commits }}+2))" >> $GITHUB_ENV
+          echo "branch=${{ github.event.pull_request.head.ref }}" >> $GITHUB_ENV
+        fi
+    - name: Checkout code
+      uses: actions/checkout@v3
+      with:
+        ref: ${{env.branch}}
+        fetch-depth: ${{env.depth}}
+    - uses: trufflesecurity/trufflehog@main
+      with:
+        extra_args: --results=verified,unknown


### PR DESCRIPTION
Refactor secret scanning not to try using private shared workflow. Public repos can't read private repo's actions
